### PR TITLE
MNT: Re-rendered with conda-smithy 2.0.1

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+* text=auto
+
+meta.yaml text eol=lf
+build.sh text eol=lf
+bld.bat text eol=crlf

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,14 +4,14 @@
 language: generic
 
 os: osx
-osx_image: beta-xcode6.1
+osx_image: xcode6.4
 
 env:
   matrix:
     
     - CONDA_PY=27
-    - CONDA_PY=34
     - CONDA_PY=35
+    - CONDA_PY=36
   global:
     # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.
     - secure: "W577QZcg1UgpDg3RGfMe6xGC8jcU8M9+mvzqyliyXi6Qr2wWBEuafEBGbfHVOddmwUe+ImblLUk1I2zrh9OlAxjwE84RB/NLGefnHieG0iHDNUj3PSMYq70N/dUD0AiFC/OPRl+XwwMAAfJdCkTQNmh1O/ct/LMRwGMnySxvs8DHNVZihOQYxwe6R5XNepno/F7si4FnEmlkfeTBEiM6dDTH/ssCMUGjKaZEo6qsUIAujM4q6Gv11BMtkde7InP6CxutcuLIyYJJyrQ3Lht9uu15bQOBPZ2vsGwkhGCbjMzKt62Hp3FOqSazWleFnJdwHCXMzVcKtFUYSL61zZ9X8Zfh1KT4b8I1lODWgcD+RmtDgs5YH911xvkjrk8FXUtLr1uYTV9S+/1++cQPF9lk3rhoe+L1eQUdUPMkiftHQ9xoDB+w2CNRvVkquraBG6FZHzCGucvr0aGnGknqSQaHV3um2TmVm9fSQal9gVJiQxx2U5cLFw/VXd3f75yGFhr6EwIyYAcIA8s+hDCPbO/JeXsriMbqNQMQHVheehmShfjJevfVCofLLSj7atxQDuamYNI7OwXvvpFuZZMXtAGk3UQiMjx7aevhLMv7fWTjimp9bST2i+qf42wZL5BXuM4D8VfAh3A/mLKvCoe37J+FLfEL025UVRvg5KllVL1a4do="
@@ -19,18 +19,32 @@ env:
 
 before_install:
     # Remove homebrew.
-    - brew remove --force $(brew list)
-    - brew cleanup -s
-    - rm -rf $(brew --cache)
+    - |
+      echo ""
+      echo "Removing homebrew from Travis CI to avoid conflicts."
+      curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/uninstall > ~/uninstall_homebrew
+      chmod +x ~/uninstall_homebrew
+      ~/uninstall_homebrew -fq
+      rm ~/uninstall_homebrew
+
 
 install:
+    # Install Miniconda.
     - |
-      MINICONDA_URL="http://repo.continuum.io/miniconda"
+      echo ""
+      echo "Installing a fresh version of Miniconda."
+      MINICONDA_URL="https://repo.continuum.io/miniconda"
       MINICONDA_FILE="Miniconda3-latest-MacOSX-x86_64.sh"
-      curl -O "${MINICONDA_URL}/${MINICONDA_FILE}"
+      curl -L -O "${MINICONDA_URL}/${MINICONDA_FILE}"
       bash $MINICONDA_FILE -b
 
+    # Configure conda.
+    - |
+      echo ""
+      echo "Configuring conda."
       source /Users/travis/miniconda3/bin/activate root
+      conda config --remove channels defaults
+      conda config --add channels defaults
       conda config --add channels conda-forge
       conda config --set show_channel_urls true
       conda install --yes --quiet conda-forge-build-setup

--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
 BSD 3-clause license
-Copyright (c) conda-forge
+Copyright (c) 2015-2017, conda-forge
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/README.md
+++ b/README.md
@@ -11,6 +11,18 @@ Summary: Python bindings for PETSc
 
 
 
+Current build status
+====================
+
+Linux: [![Circle CI](https://circleci.com/gh/conda-forge/petsc4py-feedstock.svg?style=shield)](https://circleci.com/gh/conda-forge/petsc4py-feedstock)
+OSX: [![TravisCI](https://travis-ci.org/conda-forge/petsc4py-feedstock.svg?branch=master)](https://travis-ci.org/conda-forge/petsc4py-feedstock)
+Windows: ![](https://cdn.rawgit.com/conda-forge/conda-smithy/90845bba35bec53edac7a16638aa4d77217a3713/conda_smithy/static/disabled.svg)
+
+Current release info
+====================
+Version: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/petsc4py/badges/version.svg)](https://anaconda.org/conda-forge/petsc4py)
+Downloads: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/petsc4py/badges/downloads.svg)](https://anaconda.org/conda-forge/petsc4py)
+
 Installing petsc4py
 ===================
 
@@ -31,7 +43,6 @@ It is possible to list all of the versions of `petsc4py` available on your platf
 ```
 conda search petsc4py --channel conda-forge
 ```
-
 
 
 About conda-forge
@@ -67,18 +78,6 @@ Terminology
 
 **conda-forge** - the place where the feedstock and smithy live and work to
                   produce the finished article (built conda distributions)
-
-Current build status
-====================
-
-Linux: [![Circle CI](https://circleci.com/gh/conda-forge/petsc4py-feedstock.svg?style=shield)](https://circleci.com/gh/conda-forge/petsc4py-feedstock)
-OSX: [![TravisCI](https://travis-ci.org/conda-forge/petsc4py-feedstock.svg?branch=master)](https://travis-ci.org/conda-forge/petsc4py-feedstock)
-Windows: ![](https://cdn.rawgit.com/conda-forge/conda-smithy/90845bba35bec53edac7a16638aa4d77217a3713/conda_smithy/static/disabled.svg)
-
-Current release info
-====================
-Version: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/petsc4py/badges/version.svg)](https://anaconda.org/conda-forge/petsc4py)
-Downloads: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/petsc4py/badges/downloads.svg)](https://anaconda.org/conda-forge/petsc4py)
 
 
 Updating petsc4py-feedstock

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -14,7 +14,7 @@ config=$(cat <<CONDARC
 
 channels:
  - conda-forge
- - defaults # As we need conda-build
+ - defaults
 
 conda-build:
  root-dir: /feedstock_root/build_artefacts
@@ -25,8 +25,8 @@ CONDARC
 )
 
 cat << EOF | docker run -i \
-                        -v ${RECIPE_ROOT}:/recipe_root \
-                        -v ${FEEDSTOCK_ROOT}:/feedstock_root \
+                        -v "${RECIPE_ROOT}":/recipe_root \
+                        -v "${FEEDSTOCK_ROOT}":/feedstock_root \
                         -a stdin -a stdout -a stderr \
                         condaforge/linux-anvil \
                         bash || exit $?
@@ -49,13 +49,13 @@ source run_conda_forge_build_setup
     upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
 
     set -x
-    export CONDA_PY=34
+    export CONDA_PY=35
     set +x
     conda build /recipe_root --quiet || exit 1
     upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
 
     set -x
-    export CONDA_PY=35
+    export CONDA_PY=36
     set +x
     conda build /recipe_root --quiet || exit 1
     upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1


### PR DESCRIPTION
This will make petsc4py also available for Python 3.6.