### PR TITLE
Add patch to install conf

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set build = 1 %}
+{% set build = 2 %}
 {% set version = '3.7.0' %}
 {% set md5 = '816a20040a6a477bd637f397c9fb5b6d' %}
 {% set mpi = os.environ.get('MPI') or 'mpich' %}
@@ -11,6 +11,8 @@ source:
   fn: petsc4py-{{version}}.tar.gz
   url: https://bitbucket.org/petsc/petsc4py/downloads/petsc4py-{{version}}.tar.gz
   md5: {{md5}}
+  patches:
+    - petsc4py_install_conf.patch
 
 build:
   number: {{build}}
@@ -33,6 +35,7 @@ requirements:
 test:
   imports:
     - petsc4py
+    - petsc4py.conf
     - petsc4py.PETSc
 
 about:

--- a/recipe/petsc4py_install_conf.patch
+++ b/recipe/petsc4py_install_conf.patch
@@ -1,0 +1,34 @@
+diff --git a/conf/petscconf.py b/conf/petscconf.py
+index 8cd322c..65337b3 100644
+--- a/conf/petscconf.py
++++ b/conf/petscconf.py
+@@ -14,8 +14,8 @@ __all__ = ['setup',
+ 
+ # --------------------------------------------------------------------
+ 
+-from conf.baseconf import setup, Extension
+-from conf.baseconf import config, build, build_src, build_ext, install
+-from conf.baseconf import clean, test, sdist
++from .baseconf import setup, Extension
++from .baseconf import config, build, build_src, build_ext, install
++from .baseconf import clean, test, sdist
+ 
+ # --------------------------------------------------------------------
+diff --git a/setup.py b/setup.py
+index 381d006..369e9b1 100755
+--- a/setup.py
++++ b/setup.py
+@@ -114,9 +114,11 @@ def run_setup():
+             setup_args['setup_requires'] = ['Cython>='+CYTHON]
+     #
+     setup(packages     = ['petsc4py',
+-                          'petsc4py.lib',],
++                          'petsc4py.lib',
++                          'petsc4py.conf'],
+           package_dir  = {'petsc4py'     : 'src',
+-                          'petsc4py.lib' : 'src/lib'},
++                          'petsc4py.lib' : 'src/lib',
++                          'petsc4py.conf': 'conf'},
+           package_data = {'petsc4py'     : ['include/petsc4py/*.h',
+                                             'include/petsc4py/*.i',
+                                             'include/petsc4py/*.pxd',


### PR DESCRIPTION
Patch obtained from https://github.com/hashdist/hashstack/blob/master/pkgs/petsc4py/petsc4py_install_conf.patch

Projects like https://github.com/erdc-cm/proteus depend on this.