### PR TITLE
petsc4py setup.py injects stricter dependency range than numpy ABI

### DIFF
--- a/recipe/MR7745.patch
+++ b/recipe/MR7745.patch
@@ -1,0 +1,26 @@
+From f566d94923bc9793725926f8cb3f9d964c583ae2 Mon Sep 17 00:00:00 2001
+From: Lisandro Dalcin <dalcinl@gmail.com>
+Date: Tue, 6 Aug 2024 10:03:56 +0300
+Subject: [PATCH] pip-petsc4py: Fix NumPy dependency pin
+
+https://numpy.org/doc/stable/dev/depending_on_numpy.html#numpy-2-0-specific-advice
+---
+ src/binding/petsc4py/setup.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/binding/petsc4py/setup.py b/src/binding/petsc4py/setup.py
+index f27a1ba934d..8f35fd3ec8f 100755
+--- a/src/binding/petsc4py/setup.py
++++ b/src/binding/petsc4py/setup.py
+@@ -244,7 +244,7 @@ def run_setup():
+             import numpy
+ 
+             major = int(numpy.__version__.partition('.')[0])
+-            numpy_pin = 'numpy>=%d,<%d' % (major, major + 1)
++            numpy_pin = 'numpy>=1.19' if major >= 2 else 'numpy<2'
+         except ImportError:
+             numpy_pin = 'numpy'
+         setup_args['setup_requires'] = ['numpy']
+-- 
+GitLab
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,8 +45,6 @@ requirements:
   run:
     - python
     - {{ mpi }}
-    # petsc4py injects a stricter dependency range than the numpy ABI
-    - {{ pin_compatible('numpy', min_pin='x') }}
     - petsc  # pinned by petsc run_exports
   run_constrained:
     - mpi4py >=3.0.1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,6 +12,8 @@ package:
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: {{ sha256 }}
+  patches:
+    - MR7745.patch
 
 build:
   number: {{ build }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "petsc4py" %}
 {% set version = "3.21.4" %}
 {% set sha256 = "4ba702558cc91186912eeacef26b171255f3adaa7ea02bec40c2f4c919eccecd" %}
-{% set build = 0 %}
+{% set build = 1 %}
 
 {% set version_xy = version.rsplit('.', 1)[0] %}
 
@@ -45,9 +45,17 @@ requirements:
   run:
     - python
     - {{ mpi }}
+    # petsc4py injects a stricter dependency range than the numpy ABI
+    - {{ pin_compatible('numpy', min_pin='x') }}
     - petsc  # pinned by petsc run_exports
   run_constrained:
     - mpi4py >=3.0.1
+
+test:
+  requires:
+    - pip
+  commands:
+    - pip check
 
 about:
   home: https://bitbucket.org/petsc/petsc4py


### PR DESCRIPTION
numpy 2.0 builds are ABI compatible with numpy 1.19. But petsc4py setup.py injects `numpy >=2,<3` in metadata, causing downstream `pip check` to fail with compatible numpy 1.19.

Two options:

- patch setup.py to put the right metadata in (`>=1.19,<3`), or
- make conda metadata as strict as setup.py (this PR)